### PR TITLE
 🔨 fixed link to keyrun scss

### DIFF
--- a/src/keyrune.scss
+++ b/src/keyrune.scss
@@ -5,7 +5,7 @@
   @return nth($list, 1);
 }
 
-@each $set in $mtg_setlist {
+@each $set in $keyrune_sets {
   :export {
     #{nth($set, 2)}: "#{nth($set, 1))}";
   }


### PR DESCRIPTION
Hi, I love your wrapper for keyrune!

Recently, my project started failing builds and I discovered that a recent update to keyrune broke react-keyrune. So I renamed the variable. If any other problems come up related to this one, I'll attempt to pull similar branches. 

Take care! 